### PR TITLE
Add coatjava support for "all" AHDC DREAM readout modes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
       <dependency>
         <groupId>org.jlab.coat</groupId>
         <artifactId>coat-libs</artifactId>
-        <version>12.0.0t-SNAPSHOT</version>
+        <version>12.0.1t-SNAPSHOT</version>
         <type>jar</type>
       </dependency>
     <dependency>


### PR DESCRIPTION
pending deployment of [12.0.1t](https://github.com/JeffersonLab/coatjava/releases/tag/12.0.1t)