### PR TITLE
Sync the number of wires per layer with the ccdb

### DIFF
--- a/src/main/java/org/clas/detectors/AHDCmonitor.java
+++ b/src/main/java/org/clas/detectors/AHDCmonitor.java
@@ -15,7 +15,7 @@ import org.jlab.io.base.DataEvent;
  */
 public class AHDCmonitor  extends DetectorMonitor {
 
-    static final int[] layer_wires  = {94,112,112,144,144,174,174,198};
+    static final int[] layer_wires  = {47,56,56,72,72,87,87,99};
 
     public AHDCmonitor(String name) {
         super(name);


### PR DESCRIPTION
In line 18 of https://github.com/JeffersonLab/mon12/blob/main/src/main/java/org/clas/detectors/AHDCmonitor.java,

`    static final int[] layer_wires  = {94,112,112,144,144,174,174,198};
`

seems to be twice of the number of wires per layer, when I see the related ccdb: https://clasweb.jlab.org/cgi-bin/ccdb/show_request?request=/calibration/alert/ahdc/time_offsets:0:default:2025-04-04_16-00-37 . 

Please Close #101 upon merging this.